### PR TITLE
Fix README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ go get github.com/alexfilus/go-dynamic-feature-flag/cmd/genff
 
 ## Usage
 
-genff -cfg_path=./config.yaml
+genff -cfg_path=./internal/parser/example.yaml
+
+The `-cfg_path` flag should reference a YAML configuration file.


### PR DESCRIPTION
## Summary
- update `genff` usage to point to example configuration
- clarify that `-cfg_path` must reference a YAML configuration file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841d769d06c833091608032e1b0f3c3