### PR TITLE
Add automatic formatting via go/format

### DIFF
--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go/format"
+
 	"github.com/iancoleman/strcase"
 
 	"github.com/alexfilus/go-dynamic-feature-flag/internal/model"
@@ -67,7 +69,7 @@ func Gen(cfg model.Config) error {
 
 	b.WriteString("}\n\n")
 
-        b.WriteString("type RequestDynamicConfigUpdate struct {\n")
+	b.WriteString("type RequestDynamicConfigUpdate struct {\n")
 
 	for k := range cfg.StringVars {
 		b.WriteString("\t" + strcase.ToCamel(k) + " *string `json:\"" + k + ",omitempty\"`\n")
@@ -85,27 +87,27 @@ func Gen(cfg model.Config) error {
 		b.WriteString("\t" + strcase.ToCamel(k) + " *bool `json:\"" + k + ",omitempty\"`\n")
 	}
 
-        b.WriteString("}\n\n")
+	b.WriteString("}\n\n")
 
-        b.WriteString("type ResponseDynamicConfig struct {\n")
+	b.WriteString("type ResponseDynamicConfig struct {\n")
 
-        for k := range cfg.StringVars {
-                b.WriteString("\t" + strcase.ToCamel(k) + " string `json:\"" + k + "\"`\n")
-        }
+	for k := range cfg.StringVars {
+		b.WriteString("\t" + strcase.ToCamel(k) + " string `json:\"" + k + "\"`\n")
+	}
 
-        for k := range cfg.DurationVars {
-                b.WriteString("\t" + strcase.ToCamel(k) + " time.Duration `json:\"" + k + "\"`\n")
-        }
+	for k := range cfg.DurationVars {
+		b.WriteString("\t" + strcase.ToCamel(k) + " time.Duration `json:\"" + k + "\"`\n")
+	}
 
-        for k := range cfg.IntVars {
-                b.WriteString("\t" + strcase.ToCamel(k) + " int `json:\"" + k + "\"`\n")
-        }
+	for k := range cfg.IntVars {
+		b.WriteString("\t" + strcase.ToCamel(k) + " int `json:\"" + k + "\"`\n")
+	}
 
-        for k := range cfg.BoolVars {
-                b.WriteString("\t" + strcase.ToCamel(k) + " bool `json:\"" + k + "\"`\n")
-        }
+	for k := range cfg.BoolVars {
+		b.WriteString("\t" + strcase.ToCamel(k) + " bool `json:\"" + k + "\"`\n")
+	}
 
-        b.WriteString("}\n\n")
+	b.WriteString("}\n\n")
 
 	b.WriteString("const (\n")
 	for k := range cfg.StringVars {
@@ -218,43 +220,43 @@ func Gen(cfg model.Config) error {
 		b.WriteString("return c.client.Do(\n\t\tctx, \n\t\tc.client.B().Set().Key(" + key + ").\n\t\t\tValue(strconv.Itoa(value)).\n\t\t\tBuild()).\n\t\tError()\n}\n")
 	}
 
-        for k := range cfg.BoolVars {
-                key := cfg.ToConstBool(k)
-                fieldName := strcase.ToLowerCamel(k)
-                title := strcase.ToCamel(k)
-                b.WriteString("\nfunc (c *DynamicConfig) " + title + "(ctx context.Context) bool {\n\t")
-                b.WriteString("if c.client == nil {\n\t\treturn c." + fieldName + "\n\t}\n\n")
-                b.WriteString("resp, err := c.client.DoCache(\n\t\tctx,\n\t\tc.client.B().Get().Key(" + key + ").Cache(),\n\t\ttime.Minute,\n\t).ToString()\n\n")
-                b.WriteString("\tif err != nil {\n\t\treturn c." + fieldName + "\n\t}\n\n")
-                b.WriteString("\tc." + fieldName + " = resp == \"true\"\n")
-                b.WriteString("\treturn c." + fieldName + "\n}\n")
+	for k := range cfg.BoolVars {
+		key := cfg.ToConstBool(k)
+		fieldName := strcase.ToLowerCamel(k)
+		title := strcase.ToCamel(k)
+		b.WriteString("\nfunc (c *DynamicConfig) " + title + "(ctx context.Context) bool {\n\t")
+		b.WriteString("if c.client == nil {\n\t\treturn c." + fieldName + "\n\t}\n\n")
+		b.WriteString("resp, err := c.client.DoCache(\n\t\tctx,\n\t\tc.client.B().Get().Key(" + key + ").Cache(),\n\t\ttime.Minute,\n\t).ToString()\n\n")
+		b.WriteString("\tif err != nil {\n\t\treturn c." + fieldName + "\n\t}\n\n")
+		b.WriteString("\tc." + fieldName + " = resp == \"true\"\n")
+		b.WriteString("\treturn c." + fieldName + "\n}\n")
 
-                b.WriteString("\nfunc (c *DynamicConfig) Set" + title + "(value bool) *DynamicConfig {\n\t")
-                b.WriteString("c." + fieldName + " = value\n\treturn c\n}\n")
+		b.WriteString("\nfunc (c *DynamicConfig) Set" + title + "(value bool) *DynamicConfig {\n\t")
+		b.WriteString("c." + fieldName + " = value\n\treturn c\n}\n")
 
-                b.WriteString("\nfunc (c *DynamicConfig) Store" + title + "(ctx context.Context, value bool) error {\n\t")
-                b.WriteString("return c.client.Do(\n\t\tctx, \n\t\tc.client.B().Set().Key(" + key + ").\n\t\t\tValue(strconv.FormatBool(value)).\n\t\t\tBuild()).\n\t\tError()\n}\n")
-        }
+		b.WriteString("\nfunc (c *DynamicConfig) Store" + title + "(ctx context.Context, value bool) error {\n\t")
+		b.WriteString("return c.client.Do(\n\t\tctx, \n\t\tc.client.B().Set().Key(" + key + ").\n\t\t\tValue(strconv.FormatBool(value)).\n\t\t\tBuild()).\n\t\tError()\n}\n")
+	}
 
-        b.WriteString("\nfunc (c *DynamicConfig) Config(ctx context.Context) ResponseDynamicConfig {\n")
-        b.WriteString("\treturn ResponseDynamicConfig{\n")
-        for k := range cfg.StringVars {
-                title := strcase.ToCamel(k)
-                b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
-        }
-        for k := range cfg.DurationVars {
-                title := strcase.ToCamel(k)
-                b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
-        }
-        for k := range cfg.IntVars {
-                title := strcase.ToCamel(k)
-                b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
-        }
-        for k := range cfg.BoolVars {
-                title := strcase.ToCamel(k)
-                b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
-        }
-        b.WriteString("\t}\n}\n")
+	b.WriteString("\nfunc (c *DynamicConfig) Config(ctx context.Context) ResponseDynamicConfig {\n")
+	b.WriteString("\treturn ResponseDynamicConfig{\n")
+	for k := range cfg.StringVars {
+		title := strcase.ToCamel(k)
+		b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
+	}
+	for k := range cfg.DurationVars {
+		title := strcase.ToCamel(k)
+		b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
+	}
+	for k := range cfg.IntVars {
+		title := strcase.ToCamel(k)
+		b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
+	}
+	for k := range cfg.BoolVars {
+		title := strcase.ToCamel(k)
+		b.WriteString("\t\t" + title + ": c." + title + "(ctx),\n")
+	}
+	b.WriteString("\t}\n}\n")
 
 	b.WriteString("\nfunc (c *DynamicConfig) Update(ctx context.Context, req *RequestDynamicConfigUpdate) error {\n")
 	b.WriteString("\tif c.client == nil {\n")
@@ -286,7 +288,18 @@ func Gen(cfg model.Config) error {
 
 	b.WriteString("\treturn nil\n}\n")
 
-	_, err = f.WriteString(b.String())
+	formatted, err := format.Source([]byte(b.String()))
+	if err != nil {
+		return err
+	}
 
-	return err
+	if _, err = f.Write(formatted); err != nil {
+		return err
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- use `go/format` to format generated code before writing the file

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: forbidden to download module)*

------
https://chatgpt.com/codex/tasks/task_e_6841da93eb9883308340c1016777943d